### PR TITLE
Boosted Breeding, some fixes & QoL

### DIFF
--- a/Game.ini
+++ b/Game.ini
@@ -1,6 +1,6 @@
 [/Script/ShooterGame.ShooterGameMode]
 BabyImprintingStatScaleMultiplier=1
-BabyCuddleIntervalMultiplier=0.05
+BabyCuddleIntervalMultiplier=0.02
 BabyCuddleGracePeriodMultiplier=1
 BabyCuddleLoseImprintQualitySpeedMultiplier=1
 PerLevelStatsMultiplier_DinoTamed[0]=0.200000003
@@ -69,12 +69,12 @@ IncreasePvPRespawnIntervalBaseAmount=59.9999886
 ResourceNoReplenishRadiusPlayers=0.5
 ResourceNoReplenishRadiusStructures=0.5
 CropGrowthSpeedMultiplier=2
-LayEggIntervalMultiplier=2
+LayEggIntervalMultiplier=0.2
 PoopIntervalMultiplier=1
 CropDecaySpeedMultiplier=1
 MatingIntervalMultiplier=0.05
-EggHatchSpeedMultiplier=20
-BabyMatureSpeedMultiplier=20
+EggHatchSpeedMultiplier=40
+BabyMatureSpeedMultiplier=50
 BabyFoodConsumptionSpeedMultiplier=1
 DinoTurretDamageMultiplier=1
 DinoHarvestingDamageMultiplier=2

--- a/GameUserSettings.ini
+++ b/GameUserSettings.ini
@@ -36,6 +36,7 @@ HarvestAmountMultiplier=1
 ClampResourceHarvestDamage=True
 XPMultiplier=1
 RCONEnabled=True
+ShowFloatingDamageText=true
 
 
 [ScalabilityGroups]


### PR DESCRIPTION
Cuddle muss auf 1/WachstumsMultiplier stehen, um das Imprinting komplett durchführen zu können.
LayEggIntervallMultiplier war verkehrtherum gesetzt.